### PR TITLE
Add basic FoodCodeController test

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.postgresql:postgresql'
+    testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/backend/src/test/java/com/example/halalcheck/FoodCodeControllerTest.java
+++ b/backend/src/test/java/com/example/halalcheck/FoodCodeControllerTest.java
@@ -1,0 +1,22 @@
+package com.example.halalcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class FoodCodeControllerTest {
+
+    @Autowired
+    private FoodCodeController controller;
+
+    @Test
+    void contextLoadsAndReturnsKnownCode() {
+        FoodCode result = controller.check("E100");
+        assertThat(result).isNotNull();
+        assertThat(result.getCode()).isEqualTo("E100");
+        assertThat(result.getStatus()).isEqualTo("HALAL");
+    }
+}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.data-locations=classpath:test-data.sql

--- a/backend/src/test/resources/test-data.sql
+++ b/backend/src/test/resources/test-data.sql
@@ -1,0 +1,3 @@
+INSERT INTO food_code(code, status) VALUES ('E100', 'HALAL');
+INSERT INTO food_code(code, status) VALUES ('E200', 'HARAM');
+INSERT INTO food_code(code, status) VALUES ('E300', 'MASHBUH');


### PR DESCRIPTION
## Summary
- add H2 database for tests
- create Spring Boot test verifying known food code
- add test-specific properties and data

## Testing
- `gradle -p backend test`

------
https://chatgpt.com/codex/tasks/task_e_686a6f7c4b108333804fc55510d830ce